### PR TITLE
add #196 Store attributes as boost::variant

### DIFF
--- a/ecell4/bd/BDWorld.hpp
+++ b/ecell4/bd/BDWorld.hpp
@@ -106,18 +106,17 @@ public:
 
         if (sp.has_attribute("radius") && sp.has_attribute("D"))
         {
-            radius = std::atof(sp.get_attribute("radius").c_str());
-            D = std::atof(sp.get_attribute("D").c_str());
+            radius = sp.get_attribute_as<Real>("radius");
+            D = sp.get_attribute_as<Real>("D");
         }
         else if (boost::shared_ptr<Model> bound_model = lock_model())
         {
-            Species attributed(bound_model->apply_species_attributes(sp));
-            if (attributed.has_attribute("radius")
-                && attributed.has_attribute("D"))
+            Species newsp(bound_model->apply_species_attributes(sp));
+            if (newsp.has_attribute("radius")
+                && newsp.has_attribute("D"))
             {
-                radius = std::atof(
-                    attributed.get_attribute("radius").c_str());
-                D = std::atof(attributed.get_attribute("D").c_str());
+                radius = newsp.get_attribute_as<Real>("radius");
+                D = newsp.get_attribute_as<Real>("D");
             }
         }
 

--- a/ecell4/core/Species.cpp
+++ b/ecell4/core/Species.cpp
@@ -48,9 +48,9 @@ void Species::add_unit(const UnitSpecies& usp)
     }
 }
 
-std::vector<std::pair<std::string, std::string> > Species::list_attributes() const
+std::vector<std::pair<std::string, Species::attribute_type> > Species::list_attributes() const
 {
-    std::vector<std::pair<std::string, std::string> > retval;
+    std::vector<std::pair<std::string, attribute_type> > retval;
     for (attributes_container_type::const_iterator
         i(attributes_.begin()); i != attributes_.end(); ++i)
     {
@@ -59,7 +59,7 @@ std::vector<std::pair<std::string, std::string> > Species::list_attributes() con
     return retval;
 }
 
-std::string Species::get_attribute(const std::string& name_attr) const
+Species::attribute_type Species::get_attribute(const std::string& name_attr) const
 {
     attributes_container_type::const_iterator
         i(attributes_.find(name_attr));
@@ -73,10 +73,10 @@ std::string Species::get_attribute(const std::string& name_attr) const
     return (*i).second;
 }
 
-void Species::set_attribute(const std::string& name_attr, const std::string& value)
-{
-    attributes_[name_attr] = value;
-}
+// std::string Species::get_attribute(const std::string& name_attr) const
+// {
+//     return boost::get<std::string>(get_attribute_as_variant(name_attr));
+// }
 
 void Species::set_attributes(const Species& sp)
 {

--- a/ecell4/core/Species.hpp
+++ b/ecell4/core/Species.hpp
@@ -7,6 +7,7 @@
 #include <sstream>
 #include <algorithm>
 #include <boost/algorithm/string.hpp>
+#include <boost/variant.hpp>
 
 #include <ecell4/core/config.h>
 
@@ -27,10 +28,12 @@ public:
     typedef UnitSpecies::serial_type serial_type; //XXX: std::string
     typedef std::vector<UnitSpecies> container_type;
 
+    typedef boost::variant<std::string, Real, Integer, bool> attribute_type;
+
 protected:
 
-    typedef utils::get_mapper_mf<std::string, std::string>::type
-    attributes_container_type;
+    typedef utils::get_mapper_mf<std::string, attribute_type>::type
+        attributes_container_type;
 
 public:
 
@@ -46,8 +49,19 @@ public:
         ;
     }
 
+    Species(const Species& another)
+        : serial_(another.serial()), attributes_()
+    {
+        const std::vector<std::pair<std::string, attribute_type> > attrs = another.list_attributes();
+        for (std::vector<std::pair<std::string, attribute_type> >::const_iterator
+            i(attrs.begin()); i != attrs.end(); i++)
+        {
+            set_attribute((*i).first, (*i).second);
+        }
+    }
+
     Species(
-        const serial_type& name, const std::string& radius, const std::string& D,
+        const serial_type& name, const Real& radius, const Real& D,
         const std::string location = "")
         : serial_(name), attributes_()
     {
@@ -56,15 +70,17 @@ public:
         set_attribute("location", location);
     }
 
-    Species(const Species& another)
-        : serial_(another.serial()), attributes_()
+    /*
+     * The following constructor will be deprecated. Use the above one.
+     */
+    Species(
+        const serial_type& name, const std::string& radius, const std::string& D,
+        const std::string location = "")
+        : serial_(name), attributes_()
     {
-        const std::vector<std::pair<std::string, std::string> > attrs = another.list_attributes();
-        for (std::vector<std::pair<std::string, std::string> >::const_iterator
-            i(attrs.begin()); i != attrs.end(); i++)
-        {
-            set_attribute((*i).first, (*i).second);
-        }
+        set_attribute("radius", radius);
+        set_attribute("D", D);
+        set_attribute("location", location);
     }
 
     const serial_type serial() const
@@ -95,13 +111,33 @@ public:
         return attributes_;
     }
 
-    std::vector<std::pair<std::string, std::string> > list_attributes() const;
-    std::string get_attribute(const std::string& name_attr) const;
-    void set_attribute(const std::string& name_attr, const std::string& value);
+    std::vector<std::pair<std::string, attribute_type> > list_attributes() const;
+
+    attribute_type get_attribute(const std::string& name_attr) const;
+
+    template <typename T_>
+    T_ get_attribute_as(const std::string& name_attr) const
+    {
+        attribute_type val = get_attribute(name_attr);
+        if (T_* x = boost::get<T_>(&val))
+        {
+            return (*x);
+        }
+        throw NotSupported("An attribute has incorrect type.");
+    }
+
+
+    template <typename T_>
+    void set_attribute(const std::string& name_attr, T_ value)
+    // void set_attribute(const std::string& name_attr, const T_& value)
+    {
+        attributes_[name_attr] = value;
+    }
+
     void set_attributes(const Species& sp);
-    void overwrite_attributes(const Species& sp);
     void remove_attribute(const std::string& name_attr);
     bool has_attribute(const std::string& name_attr) const;
+    void overwrite_attributes(const Species& sp);
 
     bool operator==(const Species& rhs) const;
     bool operator!=(const Species& rhs) const;
@@ -158,6 +194,31 @@ protected:
     serial_type serial_;
     attributes_container_type attributes_;
 };
+
+template <>
+inline Real Species::get_attribute_as<Real>(const std::string& name_attr) const
+{
+    attribute_type val = get_attribute(name_attr);
+    if (Real* x = boost::get<Real>(&val))
+    {
+        return (*x);
+    }
+    else if (Integer* x = boost::get<Integer>(&val))
+    {
+        return static_cast<Real>(*x);
+    }
+    else if (std::string* x = boost::get<std::string>(&val))
+    {
+        return std::atof((*x).c_str());
+    }
+    throw NotSupported("An attribute has incorrect type. Real is expected");
+}
+
+template <>
+inline void Species::set_attribute(const std::string& name_attr, const char* value)
+{
+    attributes_[name_attr] = std::string(value);
+}
 
 Species format_species(const Species& sp);
 

--- a/ecell4/core/tests/Species_test.cpp
+++ b/ecell4/core/tests/Species_test.cpp
@@ -7,6 +7,8 @@
 #   include <boost/test/included/unit_test.hpp>
 #endif
 
+#include <iostream>
+
 #include <ecell4/core/Species.hpp>
 #include <ecell4/core/Context.hpp>
 
@@ -32,12 +34,68 @@ BOOST_AUTO_TEST_CASE(Species_test_name)
 
 BOOST_AUTO_TEST_CASE(Species_test_attributes)
 {
-    Species species("test");
-    species.set_attribute("attr1", "value1");
-    species.set_attribute("attr2", "value2");
-    BOOST_CHECK_EQUAL(species.get_attribute("attr1"), "value1");
-    BOOST_CHECK_EQUAL(species.get_attribute("attr2"), "value2");
-    species.remove_attribute("attr1");
+    Species sp("test");
+
+    const std::string val1 = "foo";
+    const Real val2 = 1.5;
+    const Integer val3 = 3;
+    const bool val4 = true;
+
+    sp.set_attribute("attr1", val1);
+    sp.set_attribute("attr2", val2);
+    sp.set_attribute("attr3", val3);
+    sp.set_attribute("attr4", val4);
+    sp.set_attribute("attr5", "bar");
+
+    BOOST_ASSERT(sp.has_attribute("attr1"));
+    BOOST_ASSERT(sp.has_attribute("attr2"));
+    BOOST_ASSERT(sp.has_attribute("attr3"));
+    BOOST_ASSERT(sp.has_attribute("attr4"));
+    BOOST_ASSERT(sp.has_attribute("attr5"));
+    BOOST_ASSERT(!sp.has_attribute("atrt1"));
+
+    const Species::attribute_type attr1 = sp.get_attribute("attr1");
+    const Species::attribute_type attr2 = sp.get_attribute("attr2");
+    const Species::attribute_type attr3 = sp.get_attribute("attr3");
+    const Species::attribute_type attr4 = sp.get_attribute("attr4");
+    const Species::attribute_type attr5 = sp.get_attribute("attr5");
+
+    BOOST_ASSERT(attr1.type() == typeid(std::string));
+    BOOST_ASSERT(attr2.type() == typeid(Real));
+    BOOST_ASSERT(attr3.type() == typeid(Integer));
+    BOOST_ASSERT(attr4.type() == typeid(bool));
+    BOOST_ASSERT(attr5.type() == typeid(std::string));
+
+    BOOST_CHECK_EQUAL(boost::get<std::string>(attr1), val1);
+    BOOST_CHECK_EQUAL(boost::get<Real>(attr2), val2);
+    BOOST_CHECK_EQUAL(boost::get<Integer>(attr3), val3);
+    BOOST_CHECK_EQUAL(boost::get<bool>(attr4), val4);
+    BOOST_CHECK_EQUAL(boost::get<std::string>(attr5), "bar");
+
+    BOOST_CHECK_EQUAL(sp.get_attribute_as<std::string>("attr1"), val1);
+    BOOST_CHECK_EQUAL(sp.get_attribute_as<Real>("attr2"), val2);
+    BOOST_CHECK_EQUAL(sp.get_attribute_as<Integer>("attr3"), val3);
+    BOOST_CHECK_EQUAL(sp.get_attribute_as<bool>("attr4"), val4);
+    BOOST_CHECK_EQUAL(sp.get_attribute_as<std::string>("attr5"), "bar");
+
+    sp.remove_attribute("attr1");
+    sp.remove_attribute("attr2");
+    sp.remove_attribute("attr3");
+    sp.remove_attribute("attr4");
+    sp.remove_attribute("attr5");
+
+    BOOST_ASSERT(!sp.has_attribute("attr1"));
+    BOOST_ASSERT(!sp.has_attribute("attr2"));
+    BOOST_ASSERT(!sp.has_attribute("attr3"));
+    BOOST_ASSERT(!sp.has_attribute("attr4"));
+    BOOST_ASSERT(!sp.has_attribute("attr5"));
+
+    // Species species("test");
+    // species.set_attribute("attr1", "value1");
+    // species.set_attribute("attr2", "value2");
+    // BOOST_CHECK_EQUAL(species.get_attribute_as<std::string>("attr1"), "value1");
+    // BOOST_CHECK_EQUAL(species.get_attribute_as<std::string>("attr2"), "value2");
+    // species.remove_attribute("attr1");
 }
 
 BOOST_AUTO_TEST_CASE(Species_test_match1)

--- a/ecell4/egfrd/World.hpp
+++ b/ecell4/egfrd/World.hpp
@@ -620,35 +620,34 @@ public:
      * @param sp a species
      * @return info a molecule info
      */
-    molecule_info_type get_molecule_info(species_id_type const& sp) const
+    molecule_info_type get_molecule_info(ecell4::Species const& sp) const
     {
         ecell4::Real radius(0.0), D(0.0);
         std::string structure_id("world");
 
         if (sp.has_attribute("radius") && sp.has_attribute("D"))
         {
-            radius = std::atof(sp.get_attribute("radius").c_str());
-            D = std::atof(sp.get_attribute("D").c_str());
+            radius = sp.get_attribute_as<Real>("radius");
+            D = sp.get_attribute_as<Real>("D");
             if (sp.has_attribute("structure_id"))
             {
-                structure_id = sp.get_attribute("structure_id");
+                structure_id = sp.get_attribute_as<std::string>("structure_id");
             }
         }
         else if (boost::shared_ptr<model_type> bound_model = lock_model())
         {
-            ecell4::Species attributed(bound_model->apply_species_attributes(sp));
+            ecell4::Species newsp(bound_model->apply_species_attributes(sp));
 
-            if (attributed.has_attribute("radius")
-                && attributed.has_attribute("D"))
+            if (newsp.has_attribute("radius")
+                && newsp.has_attribute("D"))
             {
-                radius = std::atof(
-                    attributed.get_attribute("radius").c_str());
-                D = std::atof(attributed.get_attribute("D").c_str());
+                radius = newsp.get_attribute_as<Real>("radius");
+                D = newsp.get_attribute_as<Real>("D");
             }
 
-            if (sp.has_attribute("structure_id"))
+            if (newsp.has_attribute("structure_id"))
             {
-                structure_id = attributed.get_attribute("structure_id");
+                structure_id = newsp.get_attribute_as<std::string>("structure_id");
             }
         }
 

--- a/ecell4/meso/MesoscopicWorld.cpp
+++ b/ecell4/meso/MesoscopicWorld.cpp
@@ -44,26 +44,26 @@ MoleculeInfo MesoscopicWorld::get_molecule_info(const Species& sp) const
 
     if (with_loc)
     {
-        loc = sp.get_attribute("location");
+        loc = sp.get_attribute_as<std::string>("location");
     }
 
     if (with_D)
     {
-        D = std::atof(sp.get_attribute("D").c_str());
+        D = sp.get_attribute_as<Real>("D");
     }
     else
     {
         if (boost::shared_ptr<Model> bound_model = lock_model())
         {
-            Species attributed(bound_model->apply_species_attributes(sp));
-            if (attributed.has_attribute("D"))
+            Species newsp(bound_model->apply_species_attributes(sp));
+            if (newsp.has_attribute("D"))
             {
-                D = std::atof(attributed.get_attribute("D").c_str());
+                D = newsp.get_attribute_as<Real>("D");
             }
 
-            if (!with_loc && attributed.has_attribute("location"))
+            if (!with_loc && newsp.has_attribute("location"))
             {
-                loc = attributed.get_attribute("location");
+                loc = newsp.get_attribute_as<std::string>("location");
             }
         }
     }

--- a/ecell4/spatiocyte/SpatiocyteWorld.hpp
+++ b/ecell4/spatiocyte/SpatiocyteWorld.hpp
@@ -96,48 +96,40 @@ public:
         Real radius(voxel_radius()), D(0.0);
         std::string loc("");
 
-        if (with_D && with_radius)
+        if (with_D)
         {
-            radius = std::atof(sp.get_attribute("radius").c_str());
-            D = std::atof(sp.get_attribute("D").c_str());
-
-            if (with_loc)
-            {
-                loc = sp.get_attribute("location");
-            }
+            D = sp.get_attribute_as<Real>("D");
         }
-        else
+
+        if (with_radius)
         {
-            if (with_D)
-            {
-                D = std::atof(sp.get_attribute("D").c_str());
-            }
+            radius = sp.get_attribute_as<Real>("radius");
+        }
 
-            if (with_radius)
-            {
-                radius = std::atof(sp.get_attribute("radius").c_str());
-            }
+        if (with_loc)
+        {
+            loc = sp.get_attribute_as<std::string>("location");
+        }
 
-            if (with_loc)
-            {
-                loc = sp.get_attribute("location");
-            }
-
+        if (!(with_D && with_radius))  //XXX: with_loc?
+        {
             if (boost::shared_ptr<Model> bound_model = lock_model())
             {
-                Species attributed(bound_model->apply_species_attributes(sp));
-                if (!with_D && attributed.has_attribute("D"))
+                Species newsp(bound_model->apply_species_attributes(sp));
+
+                if (!with_D && newsp.has_attribute("D"))
                 {
-                    D = std::atof(attributed.get_attribute("D").c_str());
+                    D = newsp.get_attribute_as<Real>("D");
                 }
-                if (!with_radius && attributed.has_attribute("radius"))
+
+                if (!with_radius && newsp.has_attribute("radius"))
                 {
-                    radius = std::atof(
-                        attributed.get_attribute("radius").c_str());
+                    radius = newsp.get_attribute_as<Real>("radius");
                 }
-                if (!with_loc && attributed.has_attribute("location"))
+
+                if (!with_loc && newsp.has_attribute("location"))
                 {
-                    loc = attributed.get_attribute("location");
+                    loc = newsp.get_attribute_as<std::string>("location");
                 }
             }
         }

--- a/python/lib/ecell4/core.pxd
+++ b/python/lib/ecell4/core.pxd
@@ -82,12 +82,24 @@ cdef class UnitSpecies:
 
 cdef UnitSpecies UnitSpecies_from_Cpp_UnitSpecies(Cpp_UnitSpecies *sp)
 
+cdef extern from "boost/variant.hpp" namespace "boost":
+    cdef cppclass boost_variant "boost::variant" [T1, T2, T3, T4]:
+        pass
+
+    U* boost_get "boost::get" [U, T1, T2, T3, T4] (boost_variant[T1, T2, T3, T4]*) except +
+
+ctypedef boost_variant[string, Real, Integer, bool] Cpp_Species_value_type
+
+cdef boost_get_from_Cpp_Species_value_type(Cpp_Species_value_type value)
+
 ## Cpp_Species
 #  ecell4::Species
 cdef extern from "ecell4/core/Species.hpp" namespace "ecell4":
     cdef cppclass Cpp_Species "ecell4::Species":
         Cpp_Species() except +
         Cpp_Species(string) except +
+        Cpp_Species(string, Real, Real) except +
+        Cpp_Species(string, Real, Real, string) except +
         # Cpp_Species(string, string) except +
         Cpp_Species(string, string, string) except +
         Cpp_Species(string, string, string, string) except +
@@ -96,12 +108,13 @@ cdef extern from "ecell4/core/Species.hpp" namespace "ecell4":
         bool operator<(Cpp_Species& rhs)
         bool operator>(Cpp_Species& rhs)
         string serial() # string == serial_type
-        string get_attribute(string) except +
+        # string get_attribute(string) except +
+        Cpp_Species_value_type get_attribute(string) except +
+        void set_attribute[T](string, T&)
         Integer count(Cpp_Species& sp) except +
-        void set_attribute(string, string)
         void remove_attribute(string) except +
         bool has_attribute(string)
-        vector[pair[string, string]] list_attributes()
+        vector[pair[string, Cpp_Species_value_type]] list_attributes()
         void add_unit(Cpp_UnitSpecies)
         vector[Cpp_UnitSpecies]& units()
         Cpp_Species* D_ptr(string)

--- a/python/lib/ecell4/util/decorator.py
+++ b/python/lib/ecell4/util/decorator.py
@@ -259,12 +259,12 @@ class SpeciesAttributesCallback(Callback):
                         'parameter must be given as a dict; "%s" given'
                         % str(rhs))
                 for key, value in rhs.items():
-                    if not (isinstance(key, (str, bytes))
-                        and isinstance(value, (str, bytes))):
-                        raise RuntimeError(
-                            'attributes must be given as a pair of strings;'
-                            + ' "%s" and "%s" given'
-                            % (str(key), str(value)))
+                    # if not (isinstance(key, (str, bytes))
+                    #     and isinstance(value, (str, bytes))):
+                    #     raise RuntimeError(
+                    #         'attributes must be given as a pair of strings;'
+                    #         + ' "%s" and "%s" given'
+                    #         % (str(key), str(value)))
                     sp.set_attribute(key, value)
             else:
                 if not isinstance(rhs, (tuple, list)):
@@ -280,10 +280,10 @@ class SpeciesAttributesCallback(Callback):
                         % (len(self.keys), len(rhs)))
                 else:
                     for key, value in zip(self.keys, rhs):
-                        if not isinstance(value, (str, bytes)):
-                            raise RuntimeError(
-                                'paramter must be given as a string; "%s" given'
-                                % str(value))
+                        # if not isinstance(value, (str, bytes)):
+                        #     raise RuntimeError(
+                        #         'paramter must be given as a string; "%s" given'
+                        #         % str(value))
                         sp.set_attribute(key, value)
 
             self.bitwise_operations.append(sp)


### PR DESCRIPTION
add #196 Attribute accepts str, float, int, and bool

add #196 list_attributes returns a list of pairs of string and variant

add #196 get_attribute_as_variant -> get_attribute

add #196 decorator supports non-string attributes

add #196 Species constructor rather accepts floats