### PR TITLE
override ParticleContainer::apply_structure

### DIFF
--- a/ecell4/egfrd/Multi.hpp
+++ b/ecell4/egfrd/Multi.hpp
@@ -214,6 +214,12 @@ public:
     //     return world_.apply_boundary(v);
     // }
 
+    virtual position_type apply_structure(
+            position_type const& p, position_type const& d) const
+    {
+        return world_.apply_structure(p, d);
+    }
+
     virtual position_type periodic_transpose(position_type const& p0, position_type const& p1) const
     {
         return world_.periodic_transpose(p0, p1);

--- a/ecell4/egfrd/ParticleContainer.hpp
+++ b/ecell4/egfrd/ParticleContainer.hpp
@@ -130,10 +130,8 @@ public:
         return pos + disp;
     }
 
-    virtual position_type apply_structure(const position_type& pos, const position_type& disp)
-    {
-        return pos + disp;
-    }
+    virtual position_type apply_structure(
+            position_type const& pos, position_type const& disp) const = 0;
 };
 
 

--- a/ecell4/egfrd/Transaction.hpp
+++ b/ecell4/egfrd/Transaction.hpp
@@ -240,6 +240,12 @@ public:
     //     return pc_.apply_boundary(v);
     // }
 
+    virtual position_type apply_structure(
+            position_type const& p, position_type const& d) const
+    {
+        return pc_.apply_structure(p, d);
+    }
+
     virtual position_type periodic_transpose(position_type const& p0, position_type const& p1) const
     {
         return pc_.periodic_transpose(p0, p1);

--- a/ecell4/egfrd/World.hpp
+++ b/ecell4/egfrd/World.hpp
@@ -945,7 +945,7 @@ public:
 //     }
 
     virtual position_type
-    apply_structure(const position_type& pos, const position_type& disp)
+    apply_structure(const position_type& pos, const position_type& disp) const
     {
         return this->apply_structure_rec(pos, disp, Polygon<position_type>::make_nonsence_id());
     }
@@ -955,7 +955,7 @@ protected:
     // for polygon
     position_type
     apply_structure_rec(const position_type& pos, const position_type& disp,
-            const typename Polygon<position_type>::face_id_type ignore)
+            const typename Polygon<position_type>::face_id_type ignore) const
     {
         typedef typename Polygon<position_type>::face_id_type face_id_t;
 
@@ -1006,7 +1006,7 @@ protected:
 
     std::pair<position_type, position_type>
     apply_periodic_only_once(const position_type& pos, const position_type& disp,
-                             const length_type tmin, const ecell4::AABBSurface& aabb)
+            const length_type tmin, const ecell4::AABBSurface& aabb) const
     {
         //XXX: this function assumes the conditions described below is satisfied.
         // - aabb.lower = (0, 0, 0)


### PR DESCRIPTION
fix the problem that a particle goes beyond the boundary while Multi::step()