### PR TITLE
add output stream operator for DefaultLot

### DIFF
--- a/ecell4/core/Identifier.hpp
+++ b/ecell4/core/Identifier.hpp
@@ -77,6 +77,14 @@ struct DefaultLot
     }
 };
 
+template<typename Tstrm_, typename Ttraits_>
+inline std::basic_ostream<Tstrm_, Ttraits_>&
+operator<<(std::basic_ostream<Tstrm_, Ttraits_>& strm, const DefaultLot&)
+{
+    strm << '0';
+    return strm;
+}
+
 template<typename Tbase_, typename Tserial_, typename Tlot_ = DefaultLot>
 struct Identifier
 {


### PR DESCRIPTION
It is nitpicking, but I think it is good to have `operator<<(ostream, DefaultLot)`.

Currently, `operator<<(bool)` is called when we pass an instance of `DefaultLot` because it has a conversion operator `operator bool()`. It means that if a user put `std::boolalpha` to a stream before passing `SomethingID` that uses `DefaultLot` as a lot type, the output will be like this.

```console
ID(false, 42)
```

It's confusing.

Although `DefaultLot` seems [not to be used in this project](https://github.com/ecell/ecell4/search?q=DefaultLot&unscoped_q=DefaultLot), I think the output format should be kept as well as possible. So I propose formatting `DefaultLot` as `0` because `DefaultLot::operator bool()` returns `false`.