### PR TITLE
Raise an exception when a particle with no size is requested

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -21,7 +21,7 @@ jobs:
             /opt/python/$PY35/bin/python -m pip install cython
             /opt/python/$PY27/bin/python -m pip install cython
             curl -O https://cmake.org/files/v3.9/cmake-3.9.6.tar.gz
-            wget --no-check-certificate ftp://ftp.gnu.org/gnu/gsl/gsl-2.4.tar.gz
+            curl -O ftp://ftp.gnu.org/gnu/gsl/gsl-2.4.tar.gz
             curl -L -o boost_1_65_1.tar.bz2 https://dl.bintray.com/boostorg/release/1.65.1/source/boost_1_65_1.tar.bz2
             curl -LO https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8/hdf5-1.8.17/src/hdf5-1.8.17.tar.bz2
             tar xf cmake-3.9.6.tar.gz && tar xf gsl-2.4.tar.gz && tar xf hdf5-1.8.17.tar.bz2 && tar xf boost_1_65_1.tar.bz2

--- a/ecell4/bd/BDWorld.hpp
+++ b/ecell4/bd/BDWorld.hpp
@@ -6,6 +6,7 @@
 #include <boost/weak_ptr.hpp>
 #include <sstream>
 
+#include <ecell4/core/exceptions.hpp>
 #include <ecell4/core/extras.hpp>
 #include <ecell4/core/RandomNumberGenerator.hpp>
 #include <ecell4/core/SerialIDGenerator.hpp>
@@ -118,6 +119,13 @@ public:
                 radius = newsp.get_attribute_as<Real>("radius");
                 D = newsp.get_attribute_as<Real>("D");
             }
+        }
+
+        if (radius <= 0.0)
+        {
+            std::stringstream msg;
+            msg << "A particle with invalid size [" << radius << "] was given.";
+            throw IllegalArgument(msg.str());
         }
 
         MoleculeInfo info = {radius, D};

--- a/ecell4/egfrd/World.hpp
+++ b/ecell4/egfrd/World.hpp
@@ -656,6 +656,13 @@ public:
             }
         }
 
+        if (radius <= 0.0)
+        {
+            std::stringstream msg;
+            msg << "A particle with invalid size [" << radius << "] was given.";
+            throw ecell4::IllegalArgument(msg.str());
+        }
+
         molecule_info_type info = {radius, D, structure_id};
         return info;
     }

--- a/python/lib/ecell4/bd.pxd
+++ b/python/lib/ecell4/bd.pxd
@@ -38,8 +38,8 @@ cdef extern from "ecell4/bd/BDWorld.hpp" namespace "ecell4::bd":
             Cpp_Integer3& matrix_sizes,
             shared_ptr[Cpp_RandomNumberGenerator] rng) except +
 
-        pair[pair[Cpp_ParticleID, Cpp_Particle], bool] new_particle(Cpp_Particle& p)
-        pair[pair[Cpp_ParticleID, Cpp_Particle], bool] new_particle(Cpp_Species& sp, Cpp_Real3& pos)
+        pair[pair[Cpp_ParticleID, Cpp_Particle], bool] new_particle(Cpp_Particle& p) except+
+        pair[pair[Cpp_ParticleID, Cpp_Particle], bool] new_particle(Cpp_Species& sp, Cpp_Real3& pos) except+
         void set_t(Real t)
         Real t()
         Cpp_Real3& edge_lengths()
@@ -68,8 +68,8 @@ cdef extern from "ecell4/bd/BDWorld.hpp" namespace "ecell4::bd":
         # bool has_species(Cpp_Species& sp)
         Integer num_molecules(Cpp_Species& sp)
         Integer num_molecules_exact(Cpp_Species& sp)
-        void add_molecules(Cpp_Species& sp, Integer num)
-        void add_molecules(Cpp_Species& sp, Integer num, shared_ptr[Cpp_Shape])
+        void add_molecules(Cpp_Species& sp, Integer num) except+
+        void add_molecules(Cpp_Species& sp, Integer num, shared_ptr[Cpp_Shape]) except+
         void remove_molecules(Cpp_Species& sp, Integer num)
         void save(string filename) except +
         void load(string filename)

--- a/python/lib/ecell4/egfrd.pxd
+++ b/python/lib/ecell4/egfrd.pxd
@@ -32,8 +32,8 @@ cdef extern from "ecell4/egfrd/egfrd.hpp" namespace "ecell4::egfrd":
             shared_ptr[Cpp_RandomNumberGenerator]&) except +
         #     shared_ptr[Cpp_GSLRandomNumberGenerator]&) except +
         Cpp_EGFRDWorld(string&) except +
-        pair[pair[Cpp_ParticleID, Cpp_Particle], bool] new_particle(Cpp_Particle& p)
-        pair[pair[Cpp_ParticleID, Cpp_Particle], bool] new_particle(Cpp_Species& sp, Cpp_Real3& pos)
+        pair[pair[Cpp_ParticleID, Cpp_Particle], bool] new_particle(Cpp_Particle& p) except+
+        pair[pair[Cpp_ParticleID, Cpp_Particle], bool] new_particle(Cpp_Species& sp, Cpp_Real3& pos) except+
         void set_t(Real t)
         Real t()
         Cpp_Real3& edge_lengths()
@@ -64,8 +64,8 @@ cdef extern from "ecell4/egfrd/egfrd.hpp" namespace "ecell4::egfrd":
         vector[Cpp_Species] list_species()
         Integer num_molecules(Cpp_Species& sp)
         Integer num_molecules_exact(Cpp_Species& sp)
-        void add_molecules(Cpp_Species& sp, Integer num)
-        void add_molecules(Cpp_Species& sp, Integer num, shared_ptr[Cpp_Shape])
+        void add_molecules(Cpp_Species& sp, Integer num) except+
+        void add_molecules(Cpp_Species& sp, Integer num, shared_ptr[Cpp_Shape]) except+
         void remove_molecules(Cpp_Species& sp, Integer num)
         void save(string filename) except +
         void load(string filename) except +


### PR DESCRIPTION
Check if a particle has a valid radius in `get_molecule_info`.