### PR TITLE
Without HDF5 installation

### DIFF
--- a/ecell4/core/BDMLWriter.hpp
+++ b/ecell4/core/BDMLWriter.hpp
@@ -331,6 +331,20 @@ void save_bdml(
         "This method requires HDF5. The HDF5 support is turned off.");
 }
 
+void save_bd5(
+    const WorldInterface& world, const std::string& filename,
+    const int group_index,
+    const std::string& object_name,
+    const std::string& spatial_unit,
+    const std::string& time_unit,
+    const bool trunc,
+    const bool with_radius
+    )
+{
+    throw NotSupported(
+        "This method requires HDF5. The HDF5 support is turned off.");
+}
+
 }; // ecell4
 
 #endif // WITH_HDF5

--- a/ecell4/core/CompartmentSpace.hpp
+++ b/ecell4/core/CompartmentSpace.hpp
@@ -5,6 +5,7 @@
 #include "types.hpp"
 #include "exceptions.hpp"
 #include "Species.hpp"
+#include "Real3.hpp"
 // #include "Space.hpp"
 
 #ifdef WITH_HDF5

--- a/ecell4/core/VoxelSpaceBase.hpp
+++ b/ecell4/core/VoxelSpaceBase.hpp
@@ -18,6 +18,7 @@
 #endif
 
 #include "VoxelPool.hpp"
+#include "MoleculePool.hpp"
 #include "VacantType.hpp"
 #include "ParticleVoxel.hpp"
 #include "Particle.hpp"


### PR DESCRIPTION
Resolve include dependencies when the HDF5 is not installed.