### PR TITLE
fix: ensure to link boost_regex when NO_SHARED=1

### DIFF
--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -87,7 +87,7 @@ class run_tests(Command):
         test_runner = unittest.TextTestRunner()
         test_runner.run(suite)
 
-libraries = []
+libraries = ["boost_regex"]
 library_dirs = []
 
 with_cpp_shared_libraries = False


### PR DESCRIPTION
The patch for [a wheel issue](https://github.com/ecell/ecell4-wheels/issues/2)