### PR TITLE
Add a method to check units in a model

### DIFF
--- a/ecell4/extra/_unit.py
+++ b/ecell4/extra/_unit.py
@@ -1,5 +1,6 @@
 from logging import getLogger
 _log = getLogger(__name__)
+import warnings
 
 from ..util.parseobj import AnyCallable, ExpBase
 
@@ -8,9 +9,10 @@ from pint.quantity import _Quantity
 from pint.unit import _Unit
 # from pint.errors import UndefinedUnitError
 
+
 __all__ = [
-    'getUnitRegistry', '_Quantity', '_Unit', 'check_dimensionality', 'wrap_quantity',
-    'get_application_registry']
+    'getUnitRegistry', '_Quantity', '_Unit', 'wrap_quantity',
+    'get_application_registry', 'check_units']
 
 def wrapped_binary_operator(op1, op2):
     def wrapped(self, other):
@@ -73,24 +75,90 @@ def getUnitRegistry(length="meter", time="second", substance="item", volume=None
     pint.set_application_registry(ureg)  # for pickling
     return ureg
 
-def check_dimensionality(q, dim):
-    """Return whether the quantity has the dimensionality given.
-
-    Parameters
-    ----------
-    q : pint._Quantity
-    dim : pint.util.UnitsContainer
-
-    Returns
-    -------
-    value : bool
-
-    """
-    return (q._REGISTRY.get_dimensionality(dim) == q.dimensionality)
-
 def get_application_registry():
     """Just return `pint._APP_REGISTRY`."""
     return pint._APP_REGISTRY
+
+def get_dimension(model, sp):
+    sp = model.apply_species_attributes(sp)
+    if sp.has_attribute('dimension'):
+        val = sp.get_attribute('dimension')
+        assert isinstance(val, Quantity_Integer)
+        return int(val.magnitude)
+    elif sp.has_attribute('location'):
+        loc = Species(sp.get_attribute('location'))
+        return get_dimension(model, loc)
+    return 3  # default
+
+def is_structure(model, sp):
+    sp = model.apply_species_attributes(sp)
+    if not sp.has_attribute('structure'):
+        return False
+    val = sp.get_attribute('structure')
+    assert isinstance(val, bool)
+    return val
+
+def assert_units(q, dim, key=''):
+    q = q if isinstance(q, _Quantity) else getUnitRegistry().Quantity(q.magnitude, q.units)
+    if not q.check(dim):
+        raise RuntimeError('"{}" has a wrong dimensionality "{:s}". "{:s}" must be given.'.format(
+            key, q.dimensionality, getUnitRegistry().get_dimensionality(dim)))
+
+def check_units(model):
+    """
+    Check units in the given model.
+
+    Parameters
+    ----------
+    model : ecell4.core.Model
+        A model to be checked.
+
+    """
+    from ecell4_base.core import Quantity_Integer, Quantity_Real
+
+    dimensions = {
+        'D': '[length]**2/[time]',
+        'radius': '[length]',
+        'dimension': '',  # means dimensionality of 'dimensionless'
+    }
+
+    for sp in model.species_attributes():
+        for key, val in sp.list_attributes():
+            if not isinstance(val, (Quantity_Integer, Quantity_Real)):
+                continue
+            elif val.units == '':
+                continue
+            elif key not in dimensions:
+                continue
+            assert_units(val, dimensions[key], '{} ({})'.format(key, sp.serial()))
+
+    for rr in model.reaction_rules():
+        if rr.has_descriptor():
+            warnings.warn('ReactionRuleDescriptor is not supported yet. "{}" was ignored.'.format(rr.as_string()))
+            continue
+
+        val = rr.get_k()
+        if val.units == '':
+            continue
+
+        reactants = rr.reactants()
+        if len(reactants) == 0:
+            products = rr.products()
+            dim = set((get_dimension(model, sp) for sp in products))
+            if len(dim) != 1:
+                raise RuntimeError('All products must have the same dimension: "{}".'.format(rr.as_string()))
+            basedim = int(dim[0])
+            assert basedim in (1, 2, 3)
+            assert_units(val, '[substance]/[time]/[length]**{:d}'.format(basedim), rr.as_string())
+        else:
+            dim = [get_dimension(model, sp) for sp in reactants]
+            basedim = max(dim)
+            structure = [is_structure(model, sp) for sp in reactants]
+            units = '1/[time]/([substance]/[length]**{:d})**{:d}'.format(basedim, len(dim) - 1)
+            if any(structure):
+                tot = sum(dim_ for structure_, dim_ in zip(structure, dim) if structure_)
+                units += '/([length]**{:d}/[substance]**{:d})'.format(tot, sum(structure))
+            assert_units(val, units, rr.as_string())
 
 
 if __name__ == '__main__':

--- a/ecell4/extra/_unit.py
+++ b/ecell4/extra/_unit.py
@@ -79,17 +79,6 @@ def get_application_registry():
     """Just return `pint._APP_REGISTRY`."""
     return pint._APP_REGISTRY
 
-def get_dimension(model, sp):
-    sp = model.apply_species_attributes(sp)
-    if sp.has_attribute('dimension'):
-        val = sp.get_attribute('dimension')
-        assert isinstance(val, Quantity_Integer)
-        return int(val.magnitude)
-    elif sp.has_attribute('location'):
-        loc = Species(sp.get_attribute('location'))
-        return get_dimension(model, loc)
-    return 3  # default
-
 def is_structure(model, sp):
     sp = model.apply_species_attributes(sp)
     if not sp.has_attribute('structure'):
@@ -114,7 +103,18 @@ def check_units(model):
         A model to be checked.
 
     """
-    from ecell4_base.core import Quantity_Integer, Quantity_Real
+    from ecell4_base.core import Species, Quantity_Integer, Quantity_Real
+
+    def get_dimension(model, sp):
+        sp = model.apply_species_attributes(sp)
+        if sp.has_attribute('dimension'):
+            val = sp.get_attribute('dimension')
+            assert isinstance(val, Quantity_Integer)
+            return int(val.magnitude)
+        elif sp.has_attribute('location'):
+            loc = Species(sp.get_attribute('location'))
+            return get_dimension(model, loc)
+        return 3  # default
 
     dimensions = {
         'D': '[length]**2/[time]',

--- a/ecell4/extra/_unit.py
+++ b/ecell4/extra/_unit.py
@@ -54,9 +54,10 @@ def getUnitRegistry(length="meter", time="second", substance="item", volume=None
     """
     ureg = pint.UnitRegistry()
     ureg.define('item = mole / (avogadro_number * 1 mole)')
+    assert ureg.Quantity(1, 'item').check('[substance]')
 
     try:
-        pint.molar
+        ureg.molar
     # except UndefinedUnitError:
     except AttributeError:
         # https://github.com/hgrecco/pint/blob/master/pint/default_en.txt#L75-L77

--- a/ecell4/extra/unit_checker.py
+++ b/ecell4/extra/unit_checker.py
@@ -1,0 +1,184 @@
+from logging import getLogger
+_log = getLogger(__name__)
+
+import warnings
+import operator
+from functools import reduce
+
+from ecell4_base.core import Quantity_Integer, Quantity_Real, Species
+
+from ecell4.util import parseobj
+from ecell4.util.decorator_base import just_parse
+from ecell4.util.model_parser import Visitor, dispatch, RATELAW_RESERVED_FUNCTIONS
+
+from ecell4.extra._unit import *
+
+
+__all__ = ['check_units']
+
+def is_structure(model, sp):
+    sp = model.apply_species_attributes(sp)
+    if not sp.has_attribute('structure'):
+        return False
+    val = sp.get_attribute('structure')
+    assert isinstance(val, bool)
+    return val
+
+def assert_units(q, dim, key=''):
+    q = q if isinstance(q, _Quantity) else getUnitRegistry().Quantity(q.magnitude, q.units)
+    if not q.check(dim):
+        raise RuntimeError('"{}" has a wrong dimensionality "{:s}". "{:s}" must be given.'.format(
+            key, q.dimensionality, getUnitRegistry().get_dimensionality(dim)))
+
+def get_dimension(model, sp):
+    sp = model.apply_species_attributes(sp)
+    if sp.has_attribute('dimension'):
+        val = sp.get_attribute('dimension')
+        assert isinstance(val, Quantity_Integer)
+        return int(val.magnitude)
+    elif sp.has_attribute('location'):
+        loc = Species(sp.get_attribute('location'))
+        return get_dimension(model, loc)
+    return 3  # default
+
+def get_units(model, sp):
+    sp = model.apply_species_attributes(sp)
+    if sp.has_attribute('units'):
+        val = sp.get_attribute('units')
+        assert isinstance(val, str)
+        return val
+    if is_structure(model, sp):
+        ndim = get_dimension(model, sp)
+        return "meter ** {:d}".format(ndim)
+    return "item"  #XXX: Default units
+
+class DimensionalityChecker(Visitor):
+
+    OPERATORS = {
+        parseobj.PosExp: operator.pos,
+        parseobj.NegExp: operator.neg,
+        parseobj.SubExp: lambda *args: operator.sub, # reduce(operator.sub, args[1: ], args[0]),
+        parseobj.DivExp: operator.truediv, # lambda *args: reduce(operator.truediv, args[1: ], args[0]),
+        parseobj.PowExp: operator.pow,
+        parseobj.AddExp: lambda *args: reduce(operator.add, args[1: ], args[0]), # operator.add,
+        parseobj.MulExp: lambda *args: reduce(operator.mul, args[1: ], args[0]), # operator.mul,
+        # parseobj.InvExp: operator.inv,
+        # parseobj.AndExp: operator.and_,
+        # parseobj.GtExp: operator.gt,
+        # parseobj.NeExp: operator.ne,
+        # parseobj.EqExp: operator.eq,
+        }
+
+    def __init__(self, model, ureg):
+        Visitor.__init__(self)
+        self.__model = model
+        self.__ureg = ureg
+
+    def visit_const(self, obj):
+        key = obj._elems[0].name
+        if key == '_t':
+            dim = self.__ureg.parse_units("second")
+        elif key == '_v':
+            dim = self.__ureg.parse_units("meter ** 3")
+        else:
+            dim = self.__ureg.parse_units("dimensionless")
+        return dim
+
+    def visit_species(self, obj):
+        sp = Species(str(obj))
+        dim = get_units(self.__model, sp)
+        return self.__ureg.parse_units(dim)
+
+    def visit_func(self, obj, *args):
+        func = RATELAW_RESERVED_FUNCTIONS[obj._elems[0].name]
+        val = func(*(1.0 * x for _, x in args))
+        dim = val.to_base_units().u
+        return dim
+
+    def visit_expression(self, obj, *args):
+        assert len(obj._elems) == len(args)
+        for cls, op in self.OPERATORS.items():
+            if isinstance(obj, cls):
+                val = op(*[1.0 * x for x in args])
+                dim = val.to_base_units().u
+                return dim
+        raise ValueError('Unknown dimensionality for the given object [{}]'.format(str(obj)))
+
+    def visit_default(self, obj):
+        if isinstance(obj, (Quantity_Integer, Quantity_Real)):
+            dim = self.__ureg.parse_units(obj.units)
+            return dim
+        return obj
+
+def check_units_ratelaw(model, rr):
+    assert rr.has_descriptor()
+    desc = rr.get_descriptor()
+    name = desc.as_string()
+    if name == '':
+        warnings.warn('ReactionRuleDescriptor is not supported yet. "{}" was ignored.'.format(rr.as_string()))
+        return
+
+    obj = just_parse().eval(name, params={'Quantity_Integer': Quantity_Integer, 'Quantity_Real': Quantity_Real})
+    ureg = getUnitRegistry()
+    visitor = DimensionalityChecker(model, ureg)
+    try:
+        dim = dispatch(obj, visitor)
+    except Exception as err:
+        raise RuntimeError('An exception occurs while processing [{} ({})].'.format(name, rr.as_string()))
+
+    dim = ureg.Quantity(1.0, dim).to_base_units().u
+    assert_units(ureg.Quantity(1.0, dim), '[substance]/[time]', '{} ({})'.format(name, rr.as_string()))
+
+def check_units(model):
+    """
+    Check units in the given model.
+
+    Parameters
+    ----------
+    model : ecell4.core.Model
+        A model to be checked.
+
+    """
+    dimensions = {
+        'D': '[length]**2/[time]',
+        'radius': '[length]',
+        'dimension': '',  # means dimensionality of 'dimensionless'
+    }
+
+    for sp in model.species_attributes():
+        for key, val in sp.list_attributes():
+            if not isinstance(val, (Quantity_Integer, Quantity_Real)):
+                continue
+            elif val.units == '':
+                continue
+            elif key not in dimensions:
+                continue
+            assert_units(val, dimensions[key], '{} ({})'.format(key, sp.serial()))
+
+    for rr in model.reaction_rules():
+        if rr.has_descriptor():
+            check_units_ratelaw(model, rr)
+            continue
+
+        val = rr.get_k()
+        if val.units == '':
+            continue
+
+        reactants = rr.reactants()
+        if len(reactants) == 0:
+            products = rr.products()
+            dim = set((get_dimension(model, sp) for sp in products))
+            if len(dim) != 1:
+                raise RuntimeError('All products must have the same dimension: "{}".'.format(rr.as_string()))
+            basedim = int(dim[0])
+            assert basedim in (1, 2, 3)
+            assert_units(val, '[substance]/[time]/[length]**{:d}'.format(basedim), rr.as_string())
+        else:
+            dim = [get_dimension(model, sp) for sp in reactants]
+            basedim = max(dim)
+            structure = [is_structure(model, sp) for sp in reactants]
+            units = '1/[time]/([substance]/[length]**{:d})**{:d}'.format(basedim, len(dim) - 1)
+            if any(structure):
+                tot = sum(dim_ for structure_, dim_ in zip(structure, dim) if structure_)
+                units += '/([length]**{:d}/[substance]**{:d})'.format(tot, sum(structure))
+            assert_units(val, units, rr.as_string())

--- a/ecell4/util/decorator.py
+++ b/ecell4/util/decorator.py
@@ -62,7 +62,7 @@ class SpeciesAttributesCallback(Callback):
                         " '{}' was given [{}].".format(type(key).__name__, key))
 
                 value = as_quantity(value)
-                if not isinstance(value, (numbers.Real, str, bool, ecell4_base.core.Quantity)):
+                if not isinstance(value, (numbers.Real, str, bool, ecell4_base.core.Quantity_Integer, ecell4_base.core.Quantity_Real)):
                     raise TypeError(
                         "Attribute value must be int, float, string, boolean or Quantity."
                         " '{}' was given [{}].".format(type(value).__name__, value))

--- a/ecell4/util/parseobj.py
+++ b/ecell4/util/parseobj.py
@@ -162,10 +162,10 @@ class ParseElem:
                 attrs += ["%s" % str(v) for v in self.args]
             if self.kwargs is not None:
                 attrs += ["%s=%s" % (k, v) for k, v in self.kwargs.items()]
-            label += "(%s)" % (",".join(attrs))
+            label += "(%s)" % (", ".join(attrs))
 
         if self.modification is not None:
-            label += "^%s" % str(self.modification)
+            label += " ^ %s" % str(self.modification)
         if self.key is not None:
             label += "[%s]" % str(self.key)
         return label
@@ -471,7 +471,7 @@ class AddExp(ExpBase):
             self._elems.append(obj)
 
     def __str__(self):
-        return "(%s)" % ("+".join([str(obj) for obj in self._elems]))
+        return "(%s)" % (" + ".join([str(obj) for obj in self._elems]))
 
     def __deepcopy__(self, memo):
         retval = AddExp(self._root, None, None)
@@ -499,7 +499,7 @@ class SubExp(ExpBase):
             self._elems.append(obj)
 
     def __str__(self):
-        return "(%s)" % ("-".join([str(obj) for obj in self._elems]))
+        return "(%s)" % (" - ".join([str(obj) for obj in self._elems]))
 
     def __deepcopy__(self, memo):
         retval = SubExp(self._root, None, None)
@@ -527,7 +527,7 @@ class DivExp(ExpBase):
             self._elems.append(obj)
 
     def __str__(self):
-        return "(%s)" % ("/".join([str(obj) for obj in self._elems]))
+        return "(%s)" % (" / ".join([str(obj) for obj in self._elems]))
 
     def __deepcopy__(self, memo):
         retval = DivExp(self._root, None, None)
@@ -555,7 +555,7 @@ class MulExp(ExpBase):
             self._elems.append(obj)
 
     def __str__(self):
-        return "(%s)" % ("*".join([str(obj) for obj in self._elems]))
+        return "(%s)" % (" * ".join([str(obj) for obj in self._elems]))
 
     def __deepcopy__(self, memo):
         retval = MulExp(self._root, None, None)
@@ -603,7 +603,7 @@ class PowExp(ExpBase):
         return copy.copy(self._elems)
 
     def __str__(self):
-        return "pow(%s,%s)" % (self._elems[0], self._elems[1])
+        return "pow(%s, %s)" % (self._elems[0], self._elems[1])
         # return "(%s**%s)" % (self._elems[0], self._elems[1])
 
     def __deepcopy__(self, memo):
@@ -632,7 +632,7 @@ class OrExp(ExpBase):
             self._elems.append(obj)
 
     def __str__(self):
-        return "(%s)" % ("|".join([str(obj) for obj in self._elems]))
+        return "(%s)" % (" | ".join([str(obj) for obj in self._elems]))
 
     def __deepcopy__(self, memo):
         retval = OrExp(self._root, None, None)
@@ -660,7 +660,7 @@ class AndExp(ExpBase):
             self._elems.append(obj)
 
     def __str__(self):
-        return "(%s)" % ("&".join([str(obj) for obj in self._elems]))
+        return "(%s)" % (" & ".join([str(obj) for obj in self._elems]))
 
     def __deepcopy__(self, memo):
         retval = AndExp(self._root, None, None)
@@ -684,7 +684,7 @@ class CmpExp(ExpBase):
         return self.__rhs
 
     def __str__(self):
-        return "%s%s%s" % (self.__lhs, self.__opr, self.__rhs)
+        return "%s %s %s" % (self.__lhs, self.__opr, self.__rhs)
 
 class GtExp(CmpExp):
 

--- a/ecell4/util/show.py
+++ b/ecell4/util/show.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+import sys
 
 import ecell4_base
 
@@ -6,11 +7,44 @@ from .viz import plot_number_observer, plot_trajectory, plot_world
 from .simulation import load_world
 
 
-def dump_model(m):
-    res = [sp.serial() + "|" + str(dict(sp.list_attributes())) for sp in m.species_attributes()]
-    res += [rr.as_string() for rr in m.reaction_rules()]
-    # return res
-    print('\n'.join(res))
+def _as_string(val):
+    if isinstance(val, ecell4_base.core.Quantity_Integer):
+        if val.units == '':
+            return str(val.magnitude)
+        return "Quantity_Integer({:d}, '{:s}')".format(val.magnitude, val.units)
+    elif isinstance(val, ecell4_base.core.Quantity_Real):
+        if val.units == '':
+            return str(val.magnitude)
+        return "Quantity_Real({:g}, '{:s}')".format(val.magnitude, val.units)
+    elif isinstance(val, str):
+        return repr(val)
+    return str(val)
+
+def _show_species(sp, f=sys.stdout):
+    attributes = ', '.join("'{:s}': {:s}".format(key, _as_string(val)) for key, val in sp.list_attributes())
+    f.write("{:s} | {{{:s}}}\n".format(sp.serial(), attributes))
+
+def _show_reaction_rule(rr, f=sys.stdout):
+    if not rr.has_descriptor():
+        k = rr.get_k()
+        lhs = ' + '.join(sp.serial() for sp in rr.reactants())
+        rhs = ' + '.join(sp.serial() for sp in rr.products())
+        k = _as_string(k)
+    else:
+        desc = rr.get_descriptor()
+        k = rr.get_k()
+        lhs = ' + '.join('{:g} * {:s}'.format(coef, sp.serial()) if coef != 1 else sp.serial() for sp, coef in zip(rr.reactants(), desc.reactant_coefficients()))
+        rhs = ' + '.join('{:g} * {:s}'.format(coef, sp.serial()) if coef != 1 else sp.serial() for sp, coef in zip(rr.products(), desc.product_coefficients()))
+        k = desc.as_string()
+
+    f.write("{:s} > {:s} | {:s}\n".format(lhs, rhs, k))
+
+def _show_model(m, f=sys.stdout):
+    for sp in m.species_attributes():
+        _show_species(sp, f)
+    f.write('\n')
+    for rr in m.reaction_rules():
+        _show_reaction_rule(rr, f)
 
 def show(target, *args, **kwargs):
     """
@@ -31,7 +65,7 @@ def show(target, *args, **kwargs):
     elif isinstance(target, (ecell4_base.ode.ODEWorld, ecell4_base.gillespie.GillespieWorld, ecell4_base.spatiocyte.SpatiocyteWorld, ecell4_base.meso.MesoscopicWorld, ecell4_base.bd.BDWorld, ecell4_base.egfrd.EGFRDWorld)):
         plot_world(target, *args, **kwargs)
     elif isinstance(target, (ecell4_base.core.Model, ecell4_base.core.NetworkModel, ecell4_base.core.NetfreeModel)):
-        dump_model(target)
+        _show_model(target)
     elif isinstance(target, str):
         try:
             w = simulation.load_world(target)


### PR DESCRIPTION
`pint` is required.

```python
from ecell4 import *
from ecell4_base.core import Quantity_Integer, Quantity_Real

with species_attributes():
    A | B | C | {}
    D | {'location': 'M'}
    M | {'dimension': 2, 'structure': True}
    
with reaction_rules():
    A + B > C | Quantity_Real(0.01, 'um**3/item/s')
    A + M > D | Quantity_Real(1.0, 'um/s')
    A > B | Quantity_Real(1.0, 'item/s') * A / (Quantity_Integer(120, 'item') + A)

m = get_model()

from ecell4.extra.unit_checker import check_units
check_units(m)  # Nothing would occur
```